### PR TITLE
add annotation "CopyGetters"

### DIFF
--- a/src/oci/spec/runtime.rs
+++ b/src/oci/spec/runtime.rs
@@ -243,7 +243,7 @@ pub struct Box {
 }
 
 /// User specifies specific user (and group) information for the container process.
-#[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Builder, Getters)]
+#[derive(PartialEq, Eq, Serialize, Deserialize, Debug, Builder, Getters, CopyGetters)]
 #[builder(pattern = "owned", setter(into, strip_option))]
 pub struct User {
     #[getset(get_copy = "pub")]


### PR DESCRIPTION
**What type of PR is this?**

/kind design

**What this PR does / why we need it:**

Without the annotation "CopyGetters", you are not able to get direct access to uid/gid of the struct User.

**Which issue(s) this PR fixes:**

None

**Special notes for your reviewer:**

None

**Does this PR introduce a user-facing change?**

None