### PR TITLE
Replace anyhow with thiserror in sandbox crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,10 +1343,10 @@ dependencies = [
 name = "sandbox"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "bitflags",
  "derive_builder",
  "getset",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -16,7 +16,7 @@ keywords = ["runtime", "kubernetes", "cri", "container", "pod"]
 categories = ["network-programming", "api-bindings"]
 
 [dependencies]
-anyhow = "1.0.43"
+thiserror = "1.0.29"
 bitflags = "1.3.2"
 derive_builder = "0.10.2"
 getset = "0.1.1"

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, SandboxError>;
+
+#[derive(Error, Debug)]
+pub enum SandboxError {
+    #[error("uninitialized field")]
+    Builder(#[from] derive_builder::UninitializedFieldError),
+}

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -1,15 +1,16 @@
 //! Basic Pod Sandbox types
 
+pub mod error;
 pub mod pinned;
 
-use anyhow::Result;
+use crate::error::{Result, SandboxError};
 use bitflags::bitflags;
 use derive_builder::Builder;
 use getset::Getters;
 use std::{collections::HashMap, fmt, path::PathBuf};
 
 #[derive(Builder)]
-#[builder(pattern = "owned", setter(into))]
+#[builder(pattern = "owned", setter(into), build_fn(error = "SandboxError"))]
 /// This is the main data structure for a Pod Sandbox. The implementation `T` can vary and is being
 /// defined in the `Pod` trait. Responsibility of the `Sandbox` is to hold arbitrary necessary data
 /// for the implementation and not modify it in any way.
@@ -37,7 +38,11 @@ bitflags! {
 }
 
 #[derive(Builder, Getters)]
-#[builder(pattern = "owned", setter(into, strip_option))]
+#[builder(
+    pattern = "owned",
+    setter(into, strip_option),
+    build_fn(error = "SandboxError")
+)]
 /// SandboxData holds all the data which will be passed around to the `Pod` trait, too.
 pub struct SandboxData {
     #[get = "pub"]


### PR DESCRIPTION
#### What type of PR is this?
/kind dependency-change

#### What this PR does / why we need it:
For libraries we should use thiserror instead of anyhow.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
This depends on #553. I want to do this gradually starting with the sandbox crate because this is the first one where I need it.

#### Does this PR introduce a user-facing change?
```release-note
Replaced anyhow result with own result type in sandbox crate
```