### PR TITLE
Introduce sandbox context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,6 +1344,7 @@ name = "sandbox"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "common",
  "derive_builder",
  "getset",
  "thiserror",

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,3 +1,21 @@
+use std::path::PathBuf;
+
 pub mod capability;
 pub mod seccomp;
 pub mod unix_stream;
+
+#[derive(Clone, Debug)]
+pub struct Namespace {
+    pub typ: NamespaceType,
+    pub path: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+pub enum NamespaceType {
+    UTS,
+    IPC,
+    USER,
+    NET,
+    MOUNT,
+    PID,
+}

--- a/crates/network/src/cni/mod.rs
+++ b/crates/network/src/cni/mod.rs
@@ -21,7 +21,7 @@ use notify::{
     recommended_watcher, Error as NotifyError, Event, EventKind, RecommendedWatcher, RecursiveMode,
     Watcher,
 };
-use sandbox::SandboxData;
+use sandbox::SandboxConfig;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -463,7 +463,7 @@ impl CNI {
     /// Retrieve necessary data for network start/stop.
     async fn get_start_stop_data<'a, 'b>(
         &'b self,
-        sandbox_data: &'a SandboxData,
+        sandbox_data: &'a SandboxConfig,
     ) -> Result<(&'a Path, Namespace)> {
         let network_namespace_path = sandbox_data
             .network_namespace_path()
@@ -523,7 +523,7 @@ struct StorageValue {
 #[async_trait]
 impl PodNetwork for CNI {
     /// Start a new network for the provided `SandboxData`.
-    async fn start(&mut self, sandbox_data: &SandboxData) -> Result<()> {
+    async fn start(&mut self, sandbox_data: &SandboxConfig) -> Result<()> {
         info!("Starting CNI network for sandbox {}", sandbox_data.id());
         // Things intentionally skipped for sake of initial implementation simplicity:
         //
@@ -589,7 +589,7 @@ impl PodNetwork for CNI {
     }
 
     /// Stop the network of the provided `SandboxData`.
-    async fn stop(&mut self, sandbox_data: &SandboxData) -> Result<()> {
+    async fn stop(&mut self, sandbox_data: &SandboxConfig) -> Result<()> {
         info!("Stopping CNI network for sandbox {}", sandbox_data.id());
         let mut state = self.state.write().await;
         let (network_namespace_path, netns) = self.get_start_stop_data(sandbox_data).await?;

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use derive_builder::Builder;
-use sandbox::SandboxData;
+use sandbox::SandboxConfig;
 
 pub mod cni;
 
@@ -24,12 +24,12 @@ where
 /// Common network behavior trait
 pub trait PodNetwork {
     /// Start a new network for the provided `SandboxData`.
-    async fn start(&mut self, _: &SandboxData) -> Result<()> {
+    async fn start(&mut self, _: &SandboxConfig) -> Result<()> {
         Ok(())
     }
 
     /// Stop the network of the provided `SandboxData`.
-    async fn stop(&mut self, _: &SandboxData) -> Result<()> {
+    async fn stop(&mut self, _: &SandboxConfig) -> Result<()> {
         Ok(())
     }
 
@@ -45,13 +45,13 @@ where
 {
     #[allow(dead_code)]
     /// Wrapper for the implementations `start` method.
-    pub async fn start(&mut self, sandbox_data: &SandboxData) -> Result<()> {
+    pub async fn start(&mut self, sandbox_data: &SandboxConfig) -> Result<()> {
         self.implementation.start(sandbox_data).await
     }
 
     #[allow(dead_code)]
     /// Wrapper for the implementations `stop` method.
-    pub async fn stop(&mut self, sandbox_data: &SandboxData) -> Result<()> {
+    pub async fn stop(&mut self, sandbox_data: &SandboxConfig) -> Result<()> {
         self.implementation.stop(sandbox_data).await
     }
 
@@ -65,15 +65,15 @@ where
 pub mod tests {
     use std::collections::HashMap;
 
-    use sandbox::{LinuxNamespaces, SandboxDataBuilder};
+    use sandbox::{LinuxNamespaces, SandboxConfigBuilder};
 
     use super::*;
 
-    pub fn new_sandbox_data() -> Result<SandboxData> {
+    pub fn new_sandbox_data() -> Result<SandboxConfig> {
         let mut annotations: HashMap<String, String> = HashMap::new();
         annotations.insert("annotationkey1".into(), "annotationvalue1".into());
 
-        Ok(SandboxDataBuilder::default()
+        Ok(SandboxConfigBuilder::default()
             .id("uid")
             .name("name")
             .namespace("namespace")
@@ -93,12 +93,12 @@ pub mod tests {
 
     #[async_trait]
     impl PodNetwork for Mock {
-        async fn start(&mut self, _: &SandboxData) -> Result<()> {
+        async fn start(&mut self, _: &SandboxConfig) -> Result<()> {
             self.start_called = true;
             Ok(())
         }
 
-        async fn stop(&mut self, _: &SandboxData) -> Result<()> {
+        async fn stop(&mut self, _: &SandboxConfig) -> Result<()> {
             self.stop_called = true;
             Ok(())
         }

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -18,5 +18,6 @@ categories = ["network-programming", "api-bindings"]
 [dependencies]
 thiserror = "1.0.29"
 bitflags = "1.3.2"
+common = { path= "../common" }
 derive_builder = "0.10.2"
 getset = "0.1.1"


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
This introduces a sandbox context which contains the static data needed to recreate the sandbox(the SandboxConfig) and the data needed to operate the sandbox, like the pod level namespaces (the SandboxState). In the future this could also be used to inject additional dependencies into the sandbox without needing to change the interface. 

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
Introduce sandbox context
```